### PR TITLE
Fix allow_overwrite, default value changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: hashicorp/terraform:latest
+      - image: hashicorp/terraform:0.11.14
     working_directory: /app/
     steps:
       - checkout

--- a/main.tf
+++ b/main.tf
@@ -25,11 +25,11 @@ resource "aws_acm_certificate_validation" "this" {
 # We're using the list of the SAN + the main domain as a workaround
 # count      = "${length(var.subject_alternative_names)+1}"
 resource "aws_route53_record" "cert_validation" {
-  count   = "${length(var.subject_alternative_names)+1}"
-  name    = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index],"resource_record_name")}"
-  type    = "CNAME"
-  zone_id = "${var.dns_zone_id}"
-
-  records = ["${lookup(aws_acm_certificate.this.domain_validation_options[count.index],"resource_record_value")}"]
-  ttl     = "${var.dns_ttl}"
+  count           = "${length(var.subject_alternative_names)+1}"
+  name            = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index],"resource_record_name")}"
+  type            = "CNAME"
+  allow_overwrite = true
+  zone_id         = "${var.dns_zone_id}"
+  records         = ["${lookup(aws_acm_certificate.this.domain_validation_options[count.index],"resource_record_value")}"]
+  ttl             = "${var.dns_ttl}"
 }


### PR DESCRIPTION
closes: #1
Fixes allow_overwrite  default value on the  route53_record resource
ref: https://github.com/terraform-providers/terraform-provider-aws/pull/7734