### PR TITLE
Fix output source

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "arn" {
   description = "ARN associated to the generated certificate"
-  value       = "${aws_acm_certificate.this.arn}"
+  value       = "${aws_acm_certificate_validation.this.certificate_arn}"
 }


### PR DESCRIPTION
This is causing a race condition on first creation. Trying to use the certificate before it is ready either causes an error or other resource creation/update may time out and generate errors.

Certificate validation often takes AWS a while so the `aws_acm_certificate_validation` resource blocks creation of dependent resources (like ELBs) until the certificate is ready.