### PR TITLE
Fix: Error: subject_alternative_names: should be a list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 resource "aws_acm_certificate" "this" {
   domain_name               = "${var.domain_name}"
   validation_method         = "DNS"
-  subject_alternative_names = "${var.subject_alternative_names}"
+  subject_alternative_names = ["${var.subject_alternative_names}"]
   tags                      = "${var.tags}"
 }
 


### PR DESCRIPTION
I'm trying to migrate from a different module in Terraform 0.11 and hit this error:
`Error: module.certificate.aws_acm_certificate.this: subject_alternative_names: should be a list`

Forcing `subject_alternative_names` to be a list on `aws_acm_certificate` resource removes the error.

Source config:
```hcl
module "certificate" {
  source  = "jpamies/certificate/aws"
  version = "~> 0.1"

  domain_name               = "${data.aws_route53_zone.zone.name}"
  subject_alternative_names = ["*.${data.aws_route53_zone.zone.name}"]
  dns_zone_id               = "${data.aws_route53_zone.zone.zone_id}"
}
```

Terraform v0.11.14
+ provider.aws v2.21.1