### PR TITLE
upgrade to aws 3.x provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: hashicorp/terraform:0.11.14
+      - image: hashicorp/terraform:0.12.4
     working_directory: /app/
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This module can be used to create wildcard certificates, certificates with multi
 All the requested domains should be managed by the same Route53 zone.
 ## Requirements
 
-- Terraform version < 0.12
+- Terraform version >= 0.12
 
 ## How to use this Module
 
@@ -37,7 +37,7 @@ To keep using latest stable version compatible with terraform < 0.12, [https://g
 ```hcl
 module "certificate" {
   source                    = "jpamies/certificate/aws"
-  version                   = "~>0.0"
+  version                   = "~>0.1"
   domain_name               = var.domain
   subject_alternative_names = var.alternate_domains
   dns_zone_id               = var.domain_zone_id
@@ -61,10 +61,6 @@ This Module has the following folder structure:
 
 This Module follows the principles of [Semantic Versioning](http://semver.org/). You can find each new release,
 along with the changelog, in the [Releases Page](../../releases).
-
-During initial development, the major version will be 0 (e.g., `0.x.y`), which indicates the code does not yet have a
-stable API. Once we hit `1.0.0`, we will make every effort to maintain a backwards compatible API and use the MAJOR,
-MINOR, and PATCH versions on each release to indicate any incompatibilities.
 
 ## How do I contribute to this Module?
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,31 @@ All the requested domains should be managed by the same Route53 zone.
 ```hcl
 module "certificate" {
   source                    = "jpamies/certificate/aws"
-  domain_name               = "${var.domain}"
-  subject_alternative_names = ["${var.alternate_domains}"]
-  dns_zone_id               = "${var.domain_zone_id}"
-  tags                      = "${var.tags}"
+  version                   = "~>1.0"
+  domain_name               = var.domain
+  subject_alternative_names = var.alternate_domains
+  dns_zone_id               = var.domain_zone_id
+  tags                      = var.tags
 }
 ```
 
 Check [examples](https://github.com/jpamies/terraform-aws-certificate/tree/master/examples) to view a detailed working example.
+
+## Terraform < 0.12 compatibility
+
+To keep using latest stable version compatible with terraform < 0.12, [https://github.com/jpamies/terraform-aws-certificate/releases/tag/0.0.5](0.0.5). Using `~>0.0` as version you'll get all the hotfixes for old syntax.
+
+
+```hcl
+module "certificate" {
+  source                    = "jpamies/certificate/aws"
+  version                   = "~>0.0"
+  domain_name               = var.domain
+  subject_alternative_names = var.alternate_domains
+  dns_zone_id               = var.domain_zone_id
+  tags                      = var.tags
+}
+```
 
 
 ## How is structured this module

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -2,11 +2,14 @@ provider "aws" {
   region = "us-east-1"
 }
 
-variable "domain_zone_id" {}
-variable "domain" {}
+variable "domain_zone_id" {
+}
+
+variable "domain" {
+}
 
 variable "alternate_domains" {
-  type = "list"
+  type = list(string)
 }
 
 variable "tags" {
@@ -14,11 +17,11 @@ variable "tags" {
 }
 
 module "cert" {
-  source                    = ".."
-  domain_name               = "${var.domain}"
-  subject_alternative_names = ["${var.alternate_domains}"]
-  dns_zone_id               = "${var.domain_zone_id}"
-  tags                      = "${var.tags}"
+  source                    = "./.."
+  domain_name               = var.domain
+  subject_alternative_names = var.alternate_domains
+  dns_zone_id               = var.domain_zone_id
+  tags                      = var.tags
 }
 
 ######
@@ -33,7 +36,7 @@ resource "aws_elb" "bar" {
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${module.cert.arn}"
+    ssl_certificate_id = module.cert.arn
   }
 
   instances                   = []
@@ -42,7 +45,7 @@ resource "aws_elb" "bar" {
   connection_draining         = true
   connection_draining_timeout = 400
 
-  tags {
+  tags = {
     Name = "cert-elb"
   }
 }

--- a/examples/terraform.tfvars
+++ b/examples/terraform.tfvars
@@ -1,7 +1,7 @@
-domain = ""
+domain = "yourdomain.com"
 
-domain_zone_id = ""
+domain_zone_id = "yourdomain_zone_id"
 
 alternate_domains = []
 
-tags {}
+tags = {}

--- a/main.tf
+++ b/main.tf
@@ -2,16 +2,16 @@
 # AWS certificate
 ######
 resource "aws_acm_certificate" "this" {
-  domain_name               = "${var.domain_name}"
+  domain_name               = var.domain_name
   validation_method         = "DNS"
-  subject_alternative_names = "${var.subject_alternative_names}"
-  tags                      = "${var.tags}"
+  subject_alternative_names = var.subject_alternative_names
+  tags                      = var.tags
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  depends_on              = ["aws_acm_certificate.this"]
-  certificate_arn         = "${aws_acm_certificate.this.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.*.fqdn }"]
+  depends_on              = [aws_acm_certificate.this]
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = aws_route53_record.cert_validation.*.fqdn
 }
 
 ######
@@ -25,11 +25,11 @@ resource "aws_acm_certificate_validation" "this" {
 # We're using the list of the SAN + the main domain as a workaround
 # count      = "${length(var.subject_alternative_names)+1}"
 resource "aws_route53_record" "cert_validation" {
-  count           = "${length(var.subject_alternative_names)+1}"
-  name            = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index],"resource_record_name")}"
+  count           = length(var.subject_alternative_names) + 1
+  name            = aws_acm_certificate.this.domain_validation_options[count.index]["resource_record_name"]
   type            = "CNAME"
   allow_overwrite = true
-  zone_id         = "${var.dns_zone_id}"
-  records         = ["${lookup(aws_acm_certificate.this.domain_validation_options[count.index],"resource_record_value")}"]
-  ttl             = "${var.dns_ttl}"
+  zone_id         = var.dns_zone_id
+  records         = [aws_acm_certificate.this.domain_validation_options[count.index]["resource_record_value"]]
+  ttl             = var.dns_ttl
 }

--- a/tests/terraform.tfvars
+++ b/tests/terraform.tfvars
@@ -4,6 +4,6 @@ dns_zone_id = "TEST_ID"
 
 subject_alternative_names = ["alternate.testdomain.com"]
 
-tags {
+tags = {
   environment = "test"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,6 @@ variable "tags" {
 
 variable "subject_alternative_names" {
   description = "Alternate domain names  for the SSL certificate"
-  type        = "list"
+  type        = list(string)
   default     = []
 }

--- a/version.tf
+++ b/version.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "< 0.12"
+  required_version = ">= 0.12"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_acm_certificate

https://gist.github.com/agomezvidalee/73dd235d6777c98fb5ef64f9ffd48195

Please can you have a look on the changes requested due provider upgrade to 3.x, thanks!!!