### PR TITLE
Bump AWS provider to 3.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This module can be used to create wildcard certificates, certificates with multi
 All the requested domains should be managed by the same Route53 zone.
 ## Requirements
 
-- Terraform version >= 0.12
-- Terraform AWS Provider version 2.X 
+- Terraform version >= 0.12.20
+- Terraform AWS Provider version 3.X  (if you need to stay in 2.X pleas check the module version [https://github.com/jpamies/terraform-aws-certificate/releases/tag/1.0.2](1.0.2))
 
 ## How to use this Module
 

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_acm_certificate" "this" {
 resource "aws_acm_certificate_validation" "this" {
   depends_on              = [aws_acm_certificate.this]
   certificate_arn         = aws_acm_certificate.this.arn
-  validation_record_fqdns = aws_route53_record.cert_validation.*.fqdn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }
 
 ######
@@ -25,11 +25,18 @@ resource "aws_acm_certificate_validation" "this" {
 # We're using the list of the SAN + the main domain as a workaround
 # count      = "${length(var.subject_alternative_names)+1}"
 resource "aws_route53_record" "cert_validation" {
-  count           = length(var.subject_alternative_names) + 1
-  name            = aws_acm_certificate.this.domain_validation_options[count.index]["resource_record_name"]
-  type            = "CNAME"
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+
+    }
+  }
   allow_overwrite = true
-  zone_id         = var.dns_zone_id
-  records         = [aws_acm_certificate.this.domain_validation_options[count.index]["resource_record_value"]]
+  name            = each.value.name
+  records         = [each.value.record]
   ttl             = var.dns_ttl
+  type            = each.value.type
+  zone_id         = var.dns_zone_id
 }

--- a/version.tf
+++ b/version.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.20"
   required_providers {
     aws = {
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
This PR contains breaking changes cause 3.X version for the aws provider changes parameters of ACM resources.
- Code extracted from https://github.com/jpamies/terraform-aws-certificate/pull/8 
- Added some controls using required_providers in version.tf file