### PR TITLE
Fix #10 deprecate warnings from v13.4

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "arn" {
   description = "ARN associated to the generated certificate"
-  value       = "${aws_acm_certificate_validation.this.certificate_arn}"
+  value       = aws_acm_certificate_validation.this.certificate_arn
 }


### PR DESCRIPTION
Linked to issue #10 and the TF release https://github.com/hashicorp/terraform/releases/tag/v0.13.4

Removes the deprecated usage of interpolations.


  Deprecated interpolation-only expressions are detected in more contexts in addition to resources and provider configurations. Module calls, data sources, outputs, and locals are now also covered. Terraform also detects interpolation-only expressions in complex values such as lists and objects. An expression like "${foo}" should be rewritten as just foo.
